### PR TITLE
Fix block allocation size (IDFGH-13453)

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -897,6 +897,7 @@ pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes)
 
 	/* Split the block to create a zero-size sentinel block. */
 	next = block_link_next(block);
+	next->next_free = NULL;
 	block_set_size(next, 0);
 	block_set_used(next);
 	block_set_prev_free(next);

--- a/tlsf.c
+++ b/tlsf.c
@@ -897,7 +897,6 @@ pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes)
 
 	/* Split the block to create a zero-size sentinel block. */
 	next = block_link_next(block);
-	next->next_free = NULL;
 	block_set_size(next, 0);
 	block_set_used(next);
 	block_set_prev_free(next);

--- a/tlsf.c
+++ b/tlsf.c
@@ -284,8 +284,8 @@ static inline __attribute__((always_inline)) void mapping_search(control_t* cont
 {
 	if (*size >= control->small_block_size)
 	{
-		const size_t round = (1 << (tlsf_fls_sizet(*size) - control->sl_index_count_log2)) - 1;
-		*size = (*size + round) & ~round;
+		const size_t round = (1 << (tlsf_fls_sizet(*size) - control->sl_index_count_log2));
+		*size = align_up(*size, round);
 	}
 	mapping_insert(control, *size, fli, sli);
 }
@@ -545,7 +545,7 @@ static inline __attribute__((always_inline)) block_header_t* block_locate_free(c
 	int fl = 0, sl = 0;
 	block_header_t* block = 0;
 
-	if (size)
+	if (*size > 0)
 	{
 		mapping_search(control, size, &fl, &sl);
 		
@@ -1001,6 +1001,11 @@ void* tlsf_malloc(tlsf_t tlsf, size_t size)
 {
 	control_t* control = tlsf_cast(control_t*, tlsf);
 	size_t adjust = adjust_request_size(tlsf, size, ALIGN_SIZE);
+	// Returned size is 0 when the requested size is larger than the max block
+	// size.
+	if (adjust == 0) {
+		return NULL;
+	}
 	// block_locate_free() may adjust our allocated size further.
 	block_header_t* block = block_locate_free(control, &adjust);
 	return block_prepare_used(control, block, adjust);


### PR DESCRIPTION
It needs to include the rounding done by `mapping_search()` otherwise we'll trim the block too much and not be able to re-allocate the same amount of space after the block is freed.

In the paper's version of mapping_search, this is subtle because r is marked as "in out". http://www.gii.upv.es/tlsf/files/papers/jrts2008.pdf

To reproduce:
* Allocate an amount that is rounded up.
* Allocate a second block that takes up the remaining space. This prevents the second allocation from occurring in a new spot.
* Free the first block.
* Allocate the first amount a second time. It will fail without this change even though the requested space is actually available because the free block was added to the non-rounded segmented list.