### PR TITLE
Use "uintptr_t" to fix compatibility with 64-bit targets (IDFGH-15045)

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "tlsf.h"
 #include "tlsf_common.h"
 #include "tlsf_block_functions.h"
@@ -1036,11 +1037,11 @@ void* tlsf_malloc_addr(tlsf_t tlsf, size_t size, void *address)
 	control_t* control = tlsf_cast(control_t*, tlsf);
 
 	/* adjust the address to be ALIGN_SIZE bytes aligned. */
-	const unsigned int addr_adjusted = align_down(tlsf_cast(unsigned int, address), ALIGN_SIZE);
+	const uintptr_t addr_adjusted = align_down(tlsf_cast(uintptr_t, address), ALIGN_SIZE);
 
 	/* adjust the size to be ALIGN_SIZE bytes aligned. Add to the size the difference
 	 * between the requested address and the address_adjusted. */
-	size_t size_adjusted = align_up(size + (tlsf_cast(unsigned int, address) - addr_adjusted), ALIGN_SIZE);
+	size_t size_adjusted = align_up(size + (tlsf_cast(uintptr_t, address) - addr_adjusted), ALIGN_SIZE);
 
 	/* find the free block that starts before the address in the pool and is big enough
 	 * to support the size of allocation at the given address */
@@ -1080,7 +1081,7 @@ void* tlsf_malloc_addr(tlsf_t tlsf, size_t size, void *address)
 
 	/* trim any leading space or add the leading space to the overall requested size
 	 * if the leading space is not big enough to store a block of minimum size */
-	const size_t space_before_addr_adjusted = addr_adjusted - tlsf_cast(unsigned int, block_to_ptr(block));
+	const size_t space_before_addr_adjusted = addr_adjusted - tlsf_cast(uintptr_t, block_to_ptr(block));
 	block_header_t *return_block = block;
 	if (space_before_addr_adjusted >= block_size_min) {
 		return_block = block_trim_free_leading(control, block, space_before_addr_adjusted);


### PR DESCRIPTION
## Description

On 64-bit targets, casting from pointer to unsigned can lose data. Instead, cast to uintptr_t. This causes no code change on 32-bit platforms, since the types have the same width, but preserves all bits on systems where pointers are 64 bits.


## Related

No existing open issues related to this PR were identified.

## Testing

I discovered this limitation when attempting to use the tlsf allocator on an amd64 PC for CircuitPython host-based testing. While the change seems straightforward, it should be considered only lightly tested. While my project (the 'posix port') passed nearly all of its tests, I do not know that tlsf was well-exercised by the CircuitPython testsuite. 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
